### PR TITLE
feat(scripts): Make backup scope configurable via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,7 @@ FIGMA_ACCOUNT_1_AUTH_COOKIE=""
 FIGMA_ACCESS_TOKEN=""
 DOWNLOAD_PATH="" # Absolute path where files will be downloaded to
 
+TEAMS="" # Space-separated list of team IDs to download from
+PROJECTS="" # Space-separated list of project IDs to download from
+
 WAIT_TIMEOUT=10000 # Time in ms to wait between downloads (defaults to 10000)

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ node_modules/
 /playwright/.cache/
 .auth/
 .env
-/files.json
+files.json
 downloads
 figma_backups.db
 rsync.sh
+.DS_Store

--- a/scripts/run-backup.js
+++ b/scripts/run-backup.js
@@ -1,7 +1,10 @@
 const fs = require("node:fs");
 const path = require("path");
 const { execSync } = require("child_process");
+const dotenv = require("dotenv");
 const { close: closeDb } = require("./db");
+
+dotenv.config();
 
 async function runBackup() {
   try {
@@ -11,9 +14,21 @@ async function runBackup() {
       fs.unlinkSync(filesJsonPath);
     }
 
+    const teams = process.env.TEAMS;
+    const projects = process.env.PROJECTS;
+
     // Step 1: Generate files.json
-    console.log("Generating files.json...");
-    execSync("node scripts/get-team-files.js 1446837479148090378", { stdio: "inherit" });
+    if (teams) {
+      console.log(`Generating files.json for TEAMS: ${teams}...`);
+      execSync(`node scripts/get-team-files.js ${teams}`, { stdio: "inherit" });
+    }
+    else if (projects) {
+      console.log(`Generating files.json for PROJECTS: ${projects}...`);
+      execSync(`node scripts/get-project-files.js ${projects}`, { stdio: "inherit" });
+    } else {
+      console.log("PROJECTS/TEAMS are not defined in .env file. Skipping file generation.");
+      return;
+    }
 
     // Step 2: Run tests
     console.log("Running tests...");


### PR DESCRIPTION
The `run-backup.js` script now reads `TEAMS` or `PROJECTS` environment variables to determine the backup scope, removing the need for hardcoded IDs.